### PR TITLE
Allow optional record limit when syncing Airtable to Weaviate

### DIFF
--- a/sync_airtable.py
+++ b/sync_airtable.py
@@ -4,7 +4,7 @@ Create a Render *Cron Job* service that runs:
 """
 import os
 import sys
-from streamlit_app import ingest_airtable_to_weaviate  # reuse the same function
+from backend import ingest_airtable_to_weaviate
 
 if __name__ == "__main__":
     try:


### PR DESCRIPTION
## Summary
- update `sync_airtable.py` to import ingest helper from `backend`
- extend `ingest_airtable_to_weaviate` to build clients internally, accept an optional `limit` and return a status dict

## Testing
- `python -m py_compile backend.py sync_airtable.py`
- `WEAVIATE_URL=http://localhost WEAVIATE_API_KEY=dummy OPENAI_API_KEY=dummy AIRTABLE_API_KEY=dummy AIRTABLE_BASE_ID=base AIRTABLE_TABLE_NAME=table python sync_airtable.py` *(fails: Could not connect to Weaviate:Connection to Weaviate failed. .)*

------
https://chatgpt.com/codex/tasks/task_e_68c62bf6f834832782cd350b38809452