### PR TITLE
Fix indentation for PDF generation in report generation

### DIFF
--- a/sync_reports.py
+++ b/sync_reports.py
@@ -53,8 +53,8 @@ def generate_and_save_report(reports_table, name, generator_func):
 
         if "error" in report_content.lower() or "could not find" in report_content.lower():
             print(f"WARNING: Report for '{name}' generation resulted in a non-content message: {report_content}")
-        
-pdf_bytes_b64 = ""
+
+        pdf_bytes_b64 = ""
         if GENERATE_PDF:
             try:
                 pdf_bytes = backend.create_pdf(report_content, summary=name)


### PR DESCRIPTION
## Summary
- Keep PDF generation logic inside the report creation try block in `sync_reports.py`

## Testing
- `pytest`
- `python sync_reports.py` *(fails: ModuleNotFoundError: No module named 'fpdf')*

------
https://chatgpt.com/codex/tasks/task_e_68c63b0296108327a4169289ca03ef45