### PR TITLE
Fix Airtable primary field handling

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -427,8 +427,12 @@ def fetch_report(report_name):
     """Fetches a pre-generated report from the 'GeneratedReports' Airtable table."""
     logging.info(f"Fetching report '{report_name}' from Airtable.")
     try:
-        reports_table = Table(os.environ["AIRTABLE_API_KEY"], os.environ["AIRTABLE_BASE_ID"], "GeneratedReports")
-        record = reports_table.first(formula=f"{{ReportName}}='{report_name}'")
+        reports_table = Table(
+            os.environ["AIRTABLE_API_KEY"],
+            os.environ["AIRTABLE_BASE_ID"],
+            "GeneratedReports",
+        )
+        record = reports_table.first(formula=f"{{Name}}='{report_name}'")
         if record:
             return record.get("fields", {}).get("Content", "Report content not found.")
         return f"Report '{report_name}' not found."

--- a/sync_reports.py
+++ b/sync_reports.py
@@ -67,20 +67,18 @@ def generate_and_save_report(reports_table, name, generator_func):
                 print(f"Failed to generate PDF for '{name}': {pdf_err}", file=sys.stderr)
         
         record_to_save = {
-            "ReportName": sanitized_name,
+            "Name": sanitized_name,
             "Content": report_content,
-            "LastGenerated": datetime.now().isoformat()
+            "LastGenerated": datetime.now().isoformat(),
         }
         if GENERATE_PDF and attachment:
             record_to_save["PDF"] = [attachment]
+
+        key_fields = ["Name"]
         try:
-            existing_record = reports_table.first(
-                formula=f"{{ReportName}} = '{sanitized_name}'"
+            reports_table.batch_upsert(
+                [{"fields": record_to_save}], key_fields=key_fields
             )
-            if existing_record:
-                reports_table.update(existing_record["id"], record_to_save)
-            else:
-                reports_table.create(record_to_save)
         except Exception as upsert_err:
             print(
                 f"ERROR: Failed to save report for '{name}' to Airtable: {upsert_err}",


### PR DESCRIPTION
## Summary
- save reports using Airtable primary field `Name`
- fetch reports via `Name`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6482f7988832781de49e0186efaba