### PR TITLE
Ensure reports save PDF attachments correctly

### DIFF
--- a/tests/test_sync_reports.py
+++ b/tests/test_sync_reports.py
@@ -1,0 +1,30 @@
+import backend
+from sync_reports import generate_and_save_report
+
+
+class DummyTable:
+    def __init__(self):
+        self.upserts = []
+
+    def batch_upsert(self, records, key_fields=None):
+        self.upserts.append((records, key_fields))
+
+
+def test_generate_and_save_report_saves_name_and_pdf(monkeypatch):
+    table = DummyTable()
+
+    def generator_func():
+        return "Report body"
+
+    result = generate_and_save_report(table, "Sample Person", generator_func)
+
+    assert result is True
+    assert table.upserts, "batch_upsert was not called"
+    fields = table.upserts[0][0][0]["fields"]
+
+    assert fields["Name"] == backend.sanitize_name("Sample Person")
+    assert "PDF" in fields
+    attachment = fields["PDF"][0]
+    assert attachment["filename"] == f"{backend.sanitize_name('Sample Person')}.pdf"
+    assert attachment["contentType"] == "application/pdf"
+    assert isinstance(attachment["data"], (bytes, bytearray))


### PR DESCRIPTION
## Summary
- Add test confirming `generate_and_save_report` saves a PDF attachment alongside the report name

## Testing
- `pytest -q`
- `python - <<'PY'
from pyairtable import Api
import os
api_key = os.environ.get('AIRTABLE_API_KEY')
base_id = os.environ.get('AIRTABLE_BASE_ID')
print('api_key', api_key)
print('base_id', base_id)
if not api_key or not base_id:
    print('Missing Airtable credentials')
else:
    api = Api(api_key)
    base = api.get_base(base_id)
    for tbl in base.tables():
        if tbl['name']=='GeneratedReports':
            for field in tbl['fields']:
                if field['name']=='PDF':
                    print('PDF field type:', field['type'])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c6c70c0d4483278141e60c7b588928