### PR TITLE
Add configurable Airtable reports table

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Environment Variables
 
 - `OPENAI_HYDE_MODEL`: Optional. Model used for generating the hypothetical answer in the HyDE search step. Defaults to `gpt-3.5-turbo` if not set. This can also be specified via the `hyde_model` parameter when calling `backend.generative_search`.
+- `AIRTABLE_REPORTS_TABLE_NAME`: Optional. Airtable table where pre-generated reports are stored. Defaults to `GeneratedReports`.
 =======
 ## Running Tests
 

--- a/app.py
+++ b/app.py
@@ -143,7 +143,15 @@ for message in st.session_state.messages:
             st.download_button("Export as PDF", pdf_bytes, f"{message.get('summary', 'response')}.pdf", "application/pdf", key=f"pdf_{message.get('id', str(uuid.uuid4()))}")
 
 # Check for connections before allowing chat
-if not all(os.environ.get(key) for key in ["WEAVIATE_URL", "OPENAI_API_KEY", "AIRTABLE_API_KEY", "AIRTABLE_BASE_ID", "AIRTABLE_TABLE_NAME"]):
+required_env_vars = [
+    "WEAVIATE_URL",
+    "OPENAI_API_KEY",
+    "AIRTABLE_API_KEY",
+    "AIRTABLE_BASE_ID",
+    "AIRTABLE_TABLE_NAME",
+    "AIRTABLE_REPORTS_TABLE_NAME",
+]
+if not all(os.environ.get(key) for key in required_env_vars):
     st.warning("Application is not fully configured. Please check environment variables.")
 elif not connect_to_backend():
     st.warning("Could not connect to backend services. Please check your configuration and network.")

--- a/backend.py
+++ b/backend.py
@@ -424,13 +424,20 @@ def create_pdf(text_content, summary=None, sources=None):
         return b"Error: Could not generate the PDF file."
 
 def fetch_report(report_name):
-    """Fetches a pre-generated report from the 'GeneratedReports' Airtable table."""
+    """Fetches a pre-generated report from the Airtable reports table.
+
+    The table name defaults to ``"GeneratedReports"`` but can be overridden
+    via the ``AIRTABLE_REPORTS_TABLE_NAME`` environment variable.
+    """
     logging.info(f"Fetching report '{report_name}' from Airtable.")
     try:
+        reports_table_name = os.environ.get(
+            "AIRTABLE_REPORTS_TABLE_NAME", "GeneratedReports"
+        )
         reports_table = Table(
             os.environ["AIRTABLE_API_KEY"],
             os.environ["AIRTABLE_BASE_ID"],
-            "GeneratedReports",
+            reports_table_name,
         )
         record = reports_table.first(formula=f"{{Name}}='{report_name}'")
         if record:

--- a/sync_reports.py
+++ b/sync_reports.py
@@ -6,7 +6,9 @@ It performs two main tasks:
 1.  Syncs the main data table from Airtable to the Weaviate vector database.
 2.  Generates all standard analysis reports (Timeline, Conflict Report, etc.) and
     a summary for each key person, then saves the output to a separate
-    'GeneratedReports' table in Airtable for instant retrieval by the app.
+    reports table in Airtable (default name: 'GeneratedReports') for instant
+    retrieval by the app. The table name can be overridden via the
+    ``AIRTABLE_REPORTS_TABLE_NAME`` environment variable.
 """
 import os
 import sys
@@ -116,10 +118,20 @@ def main():
     # --- 3. Pre-generate Analysis Reports ---
     print("\nStarting report pre-generation...")
     try:
-        reports_table = Table(os.environ["AIRTABLE_API_KEY"], os.environ["AIRTABLE_BASE_ID"], "GeneratedReports")
-        print("Connected to 'GeneratedReports' Airtable table.")
+        reports_table_name = os.environ.get(
+            "AIRTABLE_REPORTS_TABLE_NAME", "GeneratedReports"
+        )
+        reports_table = Table(
+            os.environ["AIRTABLE_API_KEY"],
+            os.environ["AIRTABLE_BASE_ID"],
+            reports_table_name,
+        )
+        print(f"Connected to '{reports_table_name}' Airtable table.")
     except Exception as e:
-        print(f"FATAL: Could not connect to 'GeneratedReports' table in Airtable. Aborting job. Error: {e}", file=sys.stderr)
+        print(
+            f"FATAL: Could not connect to '{reports_table_name}' table in Airtable. Aborting job. Error: {e}",
+            file=sys.stderr,
+        )
         if weaviate_client and getattr(weaviate_client, "is_connected", lambda: False)():
             weaviate_client.close()
         sys.exit(1)


### PR DESCRIPTION
## Summary
- allow reports table name to be configured via `AIRTABLE_REPORTS_TABLE_NAME`
- use new environment variable in `backend.fetch_report` and `sync_reports.main`
- require the variable at app startup and document it in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6ca9111988327a1c2fde6d6047099