### PR TITLE
Use subprocess for report sync

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import os
 import backend
 import openai
 import uuid # Import uuid for unique keys
+import subprocess
 
 # --- 1. PAGE CONFIGURATION ---
 st.set_page_config(
@@ -104,8 +105,11 @@ with st.sidebar:
             with st.spinner("Syncing data and generating new reports... (this may take several minutes)"):
                 try:
                     # IMPORTANT: This should call the NEW sync script
-                    os.system("python sync_reports.py")
-                    st.toast("Data sync and report generation complete!", icon="✅")
+                    result = subprocess.run(["python", "sync_reports.py"], capture_output=True, text=True)
+                    if result.returncode == 0:
+                        st.toast(result.stdout or "Data sync and report generation complete!", icon="✅")
+                    else:
+                        st.error(result.stderr or "Sync failed")
                 except Exception as e:
                     st.error(f"Sync failed: {e}")
 


### PR DESCRIPTION
## Summary
- Replace `os.system` with `subprocess.run` for report sync
- Surface sync output or errors in the UI via `st.toast`/`st.error`

## Testing
- `pytest -q`
- Simulated success and failure cases for subprocess-based sync

------
https://chatgpt.com/codex/tasks/task_e_68c6d00e2aec8327a8be566ca24f16e3