### PR TITLE
Encode PDF attachments

### DIFF
--- a/sync_reports.py
+++ b/sync_reports.py
@@ -16,6 +16,7 @@ import logging
 import backend
 import openai
 import traceback
+import base64
 from pyairtable import Table
 from datetime import datetime
 
@@ -62,7 +63,7 @@ def generate_and_save_report(reports_table, name, generator_func):
                 pdf_bytes = backend.create_pdf(report_content, summary=name)
                 attachment = {
                     "filename": f"{sanitized_name}.pdf",
-                    "data": pdf_bytes,
+                    "data": base64.b64encode(pdf_bytes).decode("ascii"),
                     "contentType": "application/pdf",
                 }
                 print(f"PDF generated for '{name}' ({len(pdf_bytes)} bytes).")

--- a/tests/test_sync_reports.py
+++ b/tests/test_sync_reports.py
@@ -1,4 +1,5 @@
 import pytest
+import base64
 import backend
 from sync_reports import generate_and_save_report
 
@@ -28,7 +29,10 @@ def test_generate_and_save_report_saves_name_and_pdf(monkeypatch):
     attachment = fields["PDF"][0]
     assert attachment["filename"] == f"{backend.sanitize_name('Sample Person')}.pdf"
     assert attachment["contentType"] == "application/pdf"
-    assert isinstance(attachment["data"], (bytes, bytearray))
+    assert isinstance(attachment["data"], str)
+    decoded = base64.b64decode(attachment["data"])
+    expected_pdf = backend.create_pdf("Report body", summary="Sample Person")
+    assert decoded == expected_pdf
 
 
 class FailingTable:


### PR DESCRIPTION
## Summary
- Encode generated report PDFs as base64 strings before uploading to Airtable
- Adjust report generation tests to expect base64-encoded PDF data

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6d5dce72c8327bc1a9124f6c9b8da