### PR TITLE
refactor: use Api for Airtable interactions

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1,7 +1,7 @@
 import os
 import weaviate
 import openai
-from pyairtable import Table
+from pyairtable import Api
 import uuid
 import re
 import logging
@@ -68,8 +68,8 @@ def ingest_airtable_to_weaviate(weaviate_client, openai_client, chunk_size=None,
             Property(name="summary_title", data_type=DataType.TEXT),
         ]
     )
-    table = Table(
-        os.environ["AIRTABLE_API_KEY"],
+    api = Api(os.environ["AIRTABLE_API_KEY"])
+    table = api.table(
         os.environ["AIRTABLE_BASE_ID"],
         os.environ["AIRTABLE_TABLE_NAME"],
     )
@@ -434,8 +434,8 @@ def fetch_report(report_name):
         reports_table_name = os.environ.get(
             "AIRTABLE_REPORTS_TABLE_NAME", "GeneratedReports"
         )
-        reports_table = Table(
-            os.environ["AIRTABLE_API_KEY"],
+        api = Api(os.environ["AIRTABLE_API_KEY"])
+        reports_table = api.table(
             os.environ["AIRTABLE_BASE_ID"],
             reports_table_name,
         )

--- a/sync_reports.py
+++ b/sync_reports.py
@@ -17,7 +17,7 @@ import backend
 import openai
 import traceback
 import base64
-from pyairtable import Table
+from pyairtable import Api
 from datetime import datetime
 
 # --- CONFIGURATION ---
@@ -27,8 +27,8 @@ GENERATE_PDF = True  # Set to False to skip PDF generation
 def get_key_people():
     """Try to fetch key people from Airtable, otherwise fallback to static list."""
     try:
-        table = Table(
-            os.environ["AIRTABLE_API_KEY"],
+        api = Api(os.environ["AIRTABLE_API_KEY"])
+        table = api.table(
             os.environ["AIRTABLE_BASE_ID"],
             os.environ["AIRTABLE_TABLE_NAME"],
         )
@@ -131,8 +131,8 @@ def main():
         reports_table_name = os.environ.get(
             "AIRTABLE_REPORTS_TABLE_NAME", "GeneratedReports"
         )
-        reports_table = Table(
-            os.environ["AIRTABLE_API_KEY"],
+        api = Api(os.environ["AIRTABLE_API_KEY"])
+        reports_table = api.table(
             os.environ["AIRTABLE_BASE_ID"],
             reports_table_name,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,13 +34,22 @@ sys.modules["weaviate.classes.config"] = config_module
 sys.modules["weaviate.classes.init"] = init_module
 
 pyairtable_module = types.ModuleType("pyairtable")
+
 class DummyTable:
     def __init__(self, *args, **kwargs):
         pass
 
     def first(self, formula=None):
         return {"fields": {"Content": "Mocked content"}}
-pyairtable_module.Table = DummyTable
+
+class DummyApi:
+    def __init__(self, api_key):
+        pass
+
+    def table(self, base_id, table_name):
+        return DummyTable()
+
+pyairtable_module.Api = DummyApi
 sys.modules["pyairtable"] = pyairtable_module
 
 fpdf_module = types.ModuleType("fpdf")
@@ -74,4 +83,4 @@ import backend
 def mock_airtable(monkeypatch):
     monkeypatch.setenv("AIRTABLE_API_KEY", "test-key")
     monkeypatch.setenv("AIRTABLE_BASE_ID", "test-base")
-    monkeypatch.setattr(backend, "Table", DummyTable)
+    monkeypatch.setattr(backend, "Api", DummyApi)

--- a/tests/test_sync_reports.py
+++ b/tests/test_sync_reports.py
@@ -70,7 +70,14 @@ def test_get_key_people_returns_airtable_results(monkeypatch):
                 {"fields": {"Name": "Kim"}},  # duplicate
             ]
 
-    monkeypatch.setattr(sync_reports, "Table", DummyTable)
+    class DummyApi:
+        def __init__(self, api_key):
+            pass
+
+        def table(self, base_id, table_name):
+            return DummyTable()
+
+    monkeypatch.setattr(sync_reports, "Api", DummyApi)
 
     people = sync_reports.get_key_people()
 


### PR DESCRIPTION
## Summary
- replace deprecated Table usage with Api.table in `sync_reports.py`
- use Api for all Airtable access in backend and tests

## Testing
- `python -m py_compile sync_reports.py backend.py`
- `pytest -q`
- `python -W default - <<'PY'
from pyairtable import Api
api=Api('key')
api.table('base','table')
print('ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c6d811afec8327bfc0edf9a83c076e