### PR TITLE
Close Airtable API sessions and test for leaks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import types
+import warnings
 import pytest
 
 # Ensure project root is in sys.path
@@ -43,11 +44,21 @@ class DummyTable:
         return {"fields": {"Content": "Mocked content"}}
 
 class DummyApi:
+    instances = 0
+
     def __init__(self, api_key):
-        pass
+        self.closed = False
+        DummyApi.instances += 1
 
     def table(self, base_id, table_name):
         return DummyTable()
+
+    def close(self):
+        self.closed = True
+
+    def __del__(self):
+        if not self.closed:
+            warnings.warn("DummyApi not closed", ResourceWarning)
 
 pyairtable_module.Api = DummyApi
 sys.modules["pyairtable"] = pyairtable_module

--- a/tests/test_sync_reports.py
+++ b/tests/test_sync_reports.py
@@ -87,10 +87,13 @@ def test_get_key_people_returns_airtable_results(monkeypatch):
 
     class DummyApi:
         def __init__(self, api_key):
-            pass
+            self.closed = False
 
         def table(self, base_id, table_name):
             return DummyTable()
+
+        def close(self):
+            self.closed = True
 
     monkeypatch.setattr(sync_reports, "Api", DummyApi)
 


### PR DESCRIPTION
## Summary
- ensure Airtable API sessions are explicitly closed in backend and sync scripts
- allow reusing a single API instance via new `fetch_reports` helper
- extend tests with ResourceWarning checks and closing-aware dummy API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7230a2b0c8327be5ffe128b830463