### PR TITLE
Allow configurable Airtable report name field

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,11 +37,22 @@ sys.modules["weaviate.classes.init"] = init_module
 pyairtable_module = types.ModuleType("pyairtable")
 
 class DummyTable:
-    def __init__(self, *args, **kwargs):
-        pass
+    def __init__(self, fields=("Name",)):
+        self._fields = fields
 
     def first(self, formula=None):
         return {"fields": {"Content": "Mocked content"}}
+
+    def schema(self):
+        class Field:
+            def __init__(self, name):
+                self.name = name
+
+        class Schema:
+            def __init__(self, names):
+                self.fields = [Field(n) for n in names]
+
+        return Schema(self._fields)
 
 class DummyApi:
     instances = 0


### PR DESCRIPTION
## Summary
- Make `fetch_report` use a configurable `AIRTABLE_REPORT_NAME_FIELD` with a default of `Name`
- Validate Airtable schema for the configured field and raise a clear error when missing
- Update filter formula and add unit test for missing field handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c73017c584832793bf08672214ac88