### PR TITLE
Handle fpdf2 deprecations in PDF generation

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -6,7 +6,7 @@ import uuid
 import re
 import logging
 import json
-from fpdf import FPDF
+from fpdf import FPDF, XPos, YPos
 from io import BytesIO
 from weaviate.classes.config import Configure, Property, DataType
 from weaviate.classes.init import Auth
@@ -391,31 +391,46 @@ def create_pdf(text_content, summary=None, sources=None):
     try:
         pdf = FPDF()
         pdf.add_page()
-        pdf.set_font("Arial", size=12)
+        pdf.set_font("Helvetica", size=12)
 
         if summary:
-            pdf.set_font("Arial", 'B', 16)
-            pdf.cell(0, 10, summary.encode('latin-1', 'replace').decode('latin-1'), 0, 1, 'C')
+            pdf.set_font("Helvetica", 'B', 16)
+            pdf.cell(
+                0,
+                10,
+                summary.encode('latin-1', 'replace').decode('latin-1'),
+                border=0,
+                align='C',
+                new_x=XPos.LMARGIN,
+                new_y=YPos.NEXT,
+            )
             pdf.ln(10)
 
-        pdf.set_font("Arial", size=12)
+        pdf.set_font("Helvetica", size=12)
         pdf.multi_cell(0, 10, text_content.encode('latin-1', 'replace').decode('latin-1'))
         pdf.ln(5)
 
         if sources:
-            pdf.set_font("Arial", 'B', 14)
-            pdf.cell(0, 10, "Sources", 0, 1)
-            pdf.set_font("Arial", size=12)
+            pdf.set_font("Helvetica", 'B', 14)
+            pdf.cell(
+                0,
+                10,
+                "Sources",
+                border=0,
+                new_x=XPos.LMARGIN,
+                new_y=YPos.NEXT,
+            )
+            pdf.set_font("Helvetica", size=12)
             for source in sources:
                 title = source.get('title', 'Unknown Source').encode('latin-1', 'replace').decode('latin-1')
                 url = source.get('url', '')
                 pdf.set_text_color(0, 0, 255)
-                pdf.set_font('Arial', 'U', 12)
+                pdf.set_font('Helvetica', 'U', 12)
                 pdf.cell(0, 7, f"- {title}", link=url)
                 pdf.ln(5)
             pdf.set_text_color(0, 0, 0)
 
-        pdf_bytes = pdf.output(dest="S")
+        pdf_bytes = pdf.output()
         if isinstance(pdf_bytes, str):
             pdf_bytes = pdf_bytes.encode("latin-1")
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,15 +75,27 @@ pyairtable_module.Api = DummyApi
 sys.modules["pyairtable"] = pyairtable_module
 
 fpdf_module = types.ModuleType("fpdf")
+
+
+class DummyXPos:
+    LMARGIN = object()
+
+
+class DummyYPos:
+    NEXT = object()
+
+
 class DummyFPDF:
     def add_page(self):
         pass
 
-    def set_font(self, *args, **kwargs):
-        pass
+    def set_font(self, family, *args, **kwargs):
+        if family == "Arial":
+            warnings.warn("Arial font fallback is deprecated", DeprecationWarning)
 
     def cell(self, *args, **kwargs):
-        pass
+        if len(args) > 4 or "ln" in kwargs:
+            warnings.warn("'ln' argument is deprecated", DeprecationWarning)
 
     def ln(self, *args, **kwargs):
         pass
@@ -94,9 +106,15 @@ class DummyFPDF:
     def set_text_color(self, *args, **kwargs):
         pass
 
-    def output(self, dest="S"):
+    def output(self, *args, **kwargs):
+        if "dest" in kwargs:
+            warnings.warn("'dest' argument is deprecated", DeprecationWarning)
         return b"PDF"
+
+
 fpdf_module.FPDF = DummyFPDF
+fpdf_module.XPos = DummyXPos
+fpdf_module.YPos = DummyYPos
 sys.modules["fpdf"] = fpdf_module
 
 import backend

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -14,6 +14,19 @@ def test_create_pdf_returns_bytes():
     assert len(result) > 0
 
 
+def test_create_pdf_emits_no_deprecation_warnings():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        result = backend.create_pdf(
+            "Body",
+            summary="Summary",
+            sources=[{"title": "Source", "url": "https://example.com"}],
+        )
+
+    assert isinstance(result, bytes)
+    assert not any(w.category is DeprecationWarning for w in caught)
+
+
 def test_fetch_report_returns_content(mock_airtable):
     content = backend.fetch_report("Any")
     assert content == "Mocked content"


### PR DESCRIPTION
## Summary
- update PDF report creation to use the Helvetica core font, the new XPos/YPos arguments, and the modern bytes output API
- adjust the FPDF test stub to emulate deprecation warnings for Arial fonts, ln arguments, and dest="S" usage
- add coverage ensuring PDF generation completes without emitting DeprecationWarning

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb9c3a45408327b58daccbcce17c7b