### PR TITLE
Respect custom Airtable report name field

### DIFF
--- a/sync_reports.py
+++ b/sync_reports.py
@@ -77,15 +77,17 @@ def generate_and_save_report(reports_table, name, generator_func):
             except Exception as pdf_err:
                 logging.error("Failed to generate PDF for '%s': %s", name, pdf_err)
 
+        report_name_field = os.environ.get("AIRTABLE_REPORT_NAME_FIELD", "Name")
+
         record_to_save = {
-            "Name": sanitized_name,
+            report_name_field: sanitized_name,
             "Content": report_content,
             "LastGenerated": datetime.now().isoformat(),
         }
         if GENERATE_PDF and attachment:
             record_to_save["PDF"] = [attachment]
 
-        key_fields = ["Name"]
+        key_fields = [report_name_field]
         try:
             response = reports_table.batch_upsert(
                 [{"fields": record_to_save}], key_fields=key_fields

--- a/tests/test_sync_reports.py
+++ b/tests/test_sync_reports.py
@@ -38,6 +38,25 @@ def test_generate_and_save_report_sends_base64_pdf(monkeypatch):
     assert decoded == expected_pdf
 
 
+def test_generate_and_save_report_respects_custom_name_field(monkeypatch):
+    table = DummyTable()
+
+    def generator_func():
+        return "Report body"
+
+    monkeypatch.setenv("AIRTABLE_REPORT_NAME_FIELD", "ReportLabel")
+
+    generate_and_save_report(table, "Custom Person", generator_func)
+
+    records, key_fields = table.upserts[0]
+    fields = records[0]["fields"]
+
+    assert fields["ReportLabel"] == backend.sanitize_name("Custom Person")
+    assert "Name" not in fields
+    assert key_fields == ["ReportLabel"]
+    assert "PDF" in fields
+
+
 def test_generate_and_save_report_attachment_structure():
     table = DummyTable()
 


### PR DESCRIPTION
## Summary
- look up the AIRTABLE_REPORT_NAME_FIELD environment variable when saving reports so we reuse the configured name column in both the payload and key fields
- add a regression test to ensure upserts honor a custom report name field value

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cba7d16dbc8327abc14be131cc1055