### PR TITLE
Cache Weaviate client and add cleanup hook

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,8 +54,7 @@ get_or_create_session_state()
 # --- 4. BACKEND INITIALIZATION ---
 def connect_to_backend():
     try:
-        if st.session_state.weaviate_client is None:
-            st.session_state.weaviate_client = backend.connect_to_weaviate()
+        st.session_state.weaviate_client = backend.connect_to_weaviate()
         if st.session_state.openai_client is None:
             st.session_state.openai_client = openai.OpenAI(api_key=os.environ["OPENAI_API_KEY"])
         return True

--- a/sync_airtable.py
+++ b/sync_airtable.py
@@ -21,5 +21,4 @@ if __name__ == "__main__":
         print({"status": "error", "error": str(e)}, file=sys.stderr)
         sys.exit(1)
     finally:
-        if weaviate_client and getattr(weaviate_client, "is_connected", lambda: False)():
-            weaviate_client.close()
+        backend.close_cached_weaviate_client()

--- a/sync_reports.py
+++ b/sync_reports.py
@@ -246,8 +246,7 @@ def main():
             file=sys.stderr,
         )
         backend.close_airtable_api(api)
-        if weaviate_client and getattr(weaviate_client, "is_connected", lambda: False)():
-            weaviate_client.close()
+        backend.close_cached_weaviate_client()
         sys.exit(1)
 
     # --- 4. Reports Definition (easy to modify/expand) ---
@@ -282,8 +281,7 @@ def main():
 
     print("\n--- Nightly job finished ---")
     backend.close_airtable_api(api)
-    if weaviate_client and getattr(weaviate_client, "is_connected", lambda: False)():
-        weaviate_client.close()
+    backend.close_cached_weaviate_client()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- cache the Weaviate client behind `backend.connect_to_weaviate` and add an atexit hook to close it safely
- expose `backend.close_cached_weaviate_client` and use it in the sync scripts to prevent leaking sockets
- have the Streamlit app always reuse the cached client when initializing the backend

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd84ec4b8c8327b7db12c2aa12775e