### PR TITLE
Remove base64 PDF attachments from Airtable upserts

### DIFF
--- a/tests/test_sync_reports.py
+++ b/tests/test_sync_reports.py
@@ -1,5 +1,4 @@
 import pytest
-import base64
 import backend
 import sync_reports
 from sync_reports import generate_and_save_report
@@ -15,8 +14,17 @@ class DummyTable:
         return [{"id": "rec1", "fields": records[0]["fields"]}]
 
 
-def test_generate_and_save_report_sends_base64_pdf(monkeypatch):
+def test_generate_and_save_report_generates_pdf_without_uploading(monkeypatch):
     table = DummyTable()
+
+    captured = {}
+
+    def fake_create_pdf(content, summary):
+        captured["content"] = content
+        captured["summary"] = summary
+        return b"pdf-bytes"
+
+    monkeypatch.setattr(backend, "create_pdf", fake_create_pdf)
 
     def generator_func():
         return "Report body"
@@ -28,14 +36,12 @@ def test_generate_and_save_report_sends_base64_pdf(monkeypatch):
     fields = table.upserts[0][0][0]["fields"]
 
     assert fields["Name"] == backend.sanitize_name("Sample Person")
-    assert "PDF" in fields
-    attachment = fields["PDF"][0]
-    assert attachment["filename"] == f"{backend.sanitize_name('Sample Person')}.pdf"
-    assert attachment["contentType"] == "application/pdf"
-    assert isinstance(attachment["base64"], str)
-    decoded = base64.b64decode(attachment["base64"])
-    expected_pdf = backend.create_pdf("Report body", summary="Sample Person")
-    assert decoded == expected_pdf
+    assert set(fields.keys()) == {"Name", "Content", "LastGenerated"}
+    assert "PDF" not in fields
+    assert captured == {
+        "content": "Report body",
+        "summary": "Sample Person",
+    }
 
 
 def test_generate_and_save_report_respects_custom_name_field(monkeypatch):
@@ -54,10 +60,11 @@ def test_generate_and_save_report_respects_custom_name_field(monkeypatch):
     assert fields["ReportLabel"] == backend.sanitize_name("Custom Person")
     assert "Name" not in fields
     assert key_fields == ["ReportLabel"]
-    assert "PDF" in fields
+    assert set(fields.keys()) == {"ReportLabel", "Content", "LastGenerated"}
+    assert "PDF" not in fields
 
 
-def test_generate_and_save_report_attachment_structure():
+def test_generate_and_save_report_payload_contains_only_supported_fields():
     table = DummyTable()
 
     def generator_func():
@@ -66,8 +73,9 @@ def test_generate_and_save_report_attachment_structure():
     generate_and_save_report(table, "Another Person", generator_func)
 
     records, key_fields = table.upserts[0]
-    attachment = records[0]["fields"]["PDF"][0]
-    assert set(attachment.keys()) == {"filename", "base64", "contentType"}
+    fields = records[0]["fields"]
+    assert set(fields.keys()) == {"Name", "Content", "LastGenerated"}
+    assert "PDF" not in fields
 
 
 class FailingTable:


### PR DESCRIPTION
## Summary
- stop embedding base64-encoded PDF attachments in records sent to Airtable
- ensure generated report payload only contains supported fields
- update sync report tests to reflect the new attachment handling

## Testing
- pytest tests/test_sync_reports.py

------
https://chatgpt.com/codex/tasks/task_e_68cdf9f1e9548327bc8bef6717a4724d