### PR TITLE
Use current interpreter when running sync script

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 import streamlit as st
 import os
+import sys
 import backend
 import openai
 import uuid # Import uuid for unique keys
@@ -145,7 +146,7 @@ with st.sidebar:
             with st.spinner("Syncing data and generating new reports... (this may take several minutes)"):
                 try:
                     # IMPORTANT: This should call the NEW sync script
-                    result = subprocess.run(["python", "sync_reports.py"], capture_output=True, text=True)
+                    result = subprocess.run([sys.executable, "-u", "sync_reports.py"], capture_output=True, text=True)
                     if result.returncode == 0:
                         st.toast(result.stdout or "Data sync and report generation complete!", icon="✅")
                     else:


### PR DESCRIPTION
## Summary
- import sys in app.py to access the current Python interpreter path
- run the sync_reports script using sys.executable with unbuffered output

## Testing
- pytest *(fails: tests/test_sync_reports.py has an indentation error during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68cdfde2102083278adc36e855bf6e09