### PR TITLE
Disable Weaviate gRPC and update client dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 streamlit==1.37.1
-weaviate-client==4.6.0
+weaviate-client>=4.16.0,<5
+grpcio>=1.57.0,<2
 pyairtable==2.3.4
 openai>=1.30.0
 fpdf2==2.8.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,23 @@ class _Vectorizer:
 config_module.Configure = types.SimpleNamespace(Vectorizer=_Vectorizer)
 config_module.Property = object
 config_module.DataType = object
+
+
+class DummyTimeout:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+class DummyAdditionalConfig:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+config_module.AdditionalConfig = DummyAdditionalConfig
 init_module.Auth = object
+init_module.Timeout = DummyTimeout
 classes_module.config = config_module
 classes_module.init = init_module
 weaviate_module.classes = classes_module


### PR DESCRIPTION
## Summary
- disable gRPC when connecting to Weaviate WCS and configure timeouts while remaining compatible with older client signatures
- update python dependencies to require weaviate-client >=4.16 and pin grpcio for compatibility
- extend the test-time Weaviate stubs so imports succeed with the newer client API

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce04bba8a88327bb4dd4bbacece1e8