### PR TITLE
Clean whitespace before module-level tests

### DIFF
--- a/tests/test_sync_reports.py
+++ b/tests/test_sync_reports.py
@@ -41,7 +41,7 @@ def test_generate_and_save_report_skips_pdf_field(monkeypatch):
         "content": "Report body",
         "summary": "Sample Person",
     }
-    
+
 def test_generate_and_save_report_respects_custom_name_field(monkeypatch):
     table = DummyTable()
 
@@ -63,7 +63,7 @@ def test_generate_and_save_report_respects_custom_name_field(monkeypatch):
 
 
 def test_generate_and_save_report_payload_contains_only_supported_fields():
-  
+
     table = DummyTable()
 
     def generator_func():
@@ -73,7 +73,7 @@ def test_generate_and_save_report_payload_contains_only_supported_fields():
 
     records, key_fields = table.upserts[0]
     fields = records[0]["fields"]
-    
+
     assert set(fields.keys()) == {"Name", "Content", "LastGenerated"}
     assert "PDF" not in fields
 


### PR DESCRIPTION
## Summary
- remove stray indentation from blank lines around module-level tests in `tests/test_sync_reports.py`

## Testing
- pytest tests/test_sync_reports.py

------
https://chatgpt.com/codex/tasks/task_e_68ce05ca1fc8832789bd3660fff9d610