### PR TITLE
Support configurable map model for map-reduce queries

### DIFF
--- a/sync_reports.py
+++ b/sync_reports.py
@@ -23,7 +23,7 @@ from datetime import datetime
 
 # --- CONFIGURATION ---
 REPORT_MODE = os.environ.get("REPORT_MODE", "map-reduce")  # "map-reduce" or "simple"
-MAP_MODEL = os.environ.get("OPENAI_MAP_MODEL", "gpt-4o-mini-2024-07-18")
+MAP_MODEL = os.environ.get("OPENAI_MAP_MODEL", backend.DEFAULT_MAP_MODEL)
 GENERATE_PDF = True  # Set to False to skip PDF generation
 
 def _safe_int_env(var_name, default):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -430,3 +430,100 @@ def test_map_reduce_query_uses_distinct_models(monkeypatch):
     assert call["limit"] == 2
     assert call["return_properties"] == ["chunk_content"]
     assert captured_embedding["text"] == "timeline"
+
+
+def test_map_reduce_query_defaults_map_model_from_env(monkeypatch):
+    class DummyItem:
+        def __init__(self, chunk):
+            self.properties = {"chunk_content": chunk}
+
+    class DummyQuery:
+        def __init__(self):
+            self.calls = []
+
+        def near_vector(self, **kwargs):
+            self.calls.append(kwargs)
+
+            class Response:
+                objects = [DummyItem("chunk one")]
+
+            return Response()
+
+    class DummyCollection:
+        def __init__(self):
+            self.query = DummyQuery()
+
+        def iterator(self):
+            return []
+
+    class DummyCollections:
+        def __init__(self, collection):
+            self._collection = collection
+
+        def exists(self, name):
+            return True
+
+        def get(self, name):
+            return self._collection
+
+    class DummyWeaviateClient:
+        def __init__(self, collection):
+            self.collections = DummyCollections(collection)
+
+    class RecordingCompletions:
+        def __init__(self):
+            self.calls = []
+
+        def create(self, **kwargs):
+            self.calls.append(kwargs)
+            if kwargs.get("stream"):
+                return iter(["stream"])
+
+            class Message:
+                def __init__(self, content):
+                    self.content = content
+
+            class Choice:
+                def __init__(self, content):
+                    self.message = Message(content)
+
+            class Response:
+                def __init__(self, content):
+                    self.choices = [Choice(content)]
+
+            return Response("Mapped info")
+
+    class DummyChat:
+        def __init__(self, completions):
+            self.completions = completions
+
+    class DummyOpenAIClient:
+        def __init__(self, completions):
+            self.chat = DummyChat(completions)
+
+    monkeypatch.setenv("OPENAI_MAP_MODEL", "cheap-model")
+
+    def fake_embedding(text, client):
+        return [0.1, 0.2]
+
+    monkeypatch.setattr(backend, "get_embedding", fake_embedding)
+
+    completions = RecordingCompletions()
+    openai_client = DummyOpenAIClient(completions)
+    collection = DummyCollection()
+    weaviate_client = DummyWeaviateClient(collection)
+
+    backend._map_reduce_query(
+        weaviate_client,
+        openai_client,
+        map_prompt_template="{chunk_content}",
+        reduce_prompt_template="{combined_text}",
+        model="reduce-model",
+        fallback_search={"query": "timeline", "limit": 1},
+    )
+
+    map_calls = [call for call in completions.calls if not call.get("stream")]
+    reduce_calls = [call for call in completions.calls if call.get("stream")]
+
+    assert map_calls and {call["model"] for call in map_calls} == {"cheap-model"}
+    assert reduce_calls and reduce_calls[0]["model"] == "reduce-model"


### PR DESCRIPTION
## Summary
- allow map-reduce helper to resolve a dedicated map model via environment overrides and share the default across modules
- pass the resolved map model through sync_reports so cron jobs use the cheaper map stage model
- extend backend tests to cover both explicit and environment-driven map/reduce model selection

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce17c0b6c083278b489d9ace616bbf