### PR TITLE
Handle dynamic timeout keyword when connecting to Weaviate

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -72,10 +72,12 @@ def test_connect_to_weaviate_uses_modern_helper(monkeypatch):
     assert captured_kwargs["cluster_url"] == "https://cloud"
     assert captured_kwargs["auth_credentials"] == ("api_key", "api-key")
     assert captured_kwargs["headers"] == {"X-OpenAI-Api-Key": "openai-key"}
-    assert "timeout" not in captured_kwargs
     assert "grpc" not in captured_kwargs
-    assert isinstance(captured_kwargs["timeout_config"], DummyTimeout)
-    assert captured_kwargs["timeout_config"].kwargs == {
+    timeout_keys = {"timeout", "timeout_config"} & captured_kwargs.keys()
+    assert len(timeout_keys) == 1
+    timeout_key = timeout_keys.pop()
+    assert isinstance(captured_kwargs[timeout_key], DummyTimeout)
+    assert captured_kwargs[timeout_key].kwargs == {
         "init": 10,
         "insert": 120,
         "query": 60,


### PR DESCRIPTION
## Summary
- inspect the available Weaviate cloud connection helper to determine whether it expects `timeout` or `timeout_config`
- continue removing unsupported keyword arguments while routing the timeout to the detected parameter
- update the backend test to accept the dynamically selected timeout keyword

## Testing
- pytest tests/test_backend.py::test_connect_to_weaviate_uses_modern_helper

------
https://chatgpt.com/codex/tasks/task_e_68ce2023120483278ad71f460e37310e